### PR TITLE
Extend search for fishing trip request

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <artifactId>activity-model</artifactId>
     <name>activity-model</name>
     <packaging>ejb</packaging>
-    <version>0.5.13</version>
+    <version>0.5.14-SNAPSHOT</version>
     <description>This module shall have interfaces, XSD, and DTOs</description>
 
     <properties>

--- a/src/main/resources/contract/Activity_CommonTypes.xsd
+++ b/src/main/resources/contract/Activity_CommonTypes.xsd
@@ -121,6 +121,10 @@
                 <xs:element name="ports" type="xs:string"  minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="areas" type="xs:string"  minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="vesselIdentifiers" type="VesselIdentifierType" minOccurs="0" maxOccurs="unbounded"/>
+				<xs:element name="occurence" minOccurs="0" maxOccurs="1" type="xs:dateTime"/>
+                <xs:element name="landingReferencedID" minOccurs="0" maxOccurs="1" type="xs:string"/>
+                <xs:element name="landingState" minOccurs="0" maxOccurs="1" type="xs:string"/>
+                <xs:element name="vesselContactParty" type="VesselContactPartyType" minOccurs="0" maxOccurs="1"/>
             </xs:sequence>
     </xs:complexType>
 
@@ -151,6 +155,7 @@
             <xs:enumeration value="AREA_GEOM"/>
             <xs:enumeration value="ACTIVITY_TYPE"/>
             <xs:enumeration value="TRIP_ID"/>
+            <xs:enumeration value="CONTACT_ROLE_CODE"/>
         </xs:restriction>
     </xs:simpleType>
 
@@ -230,6 +235,18 @@
         </xs:complexType>
     </xs:element>
 
-
+    <xs:complexType name="VesselContactPartyType">
+        <xs:sequence>
+            <xs:element name="role" type="xs:string"/>
+            <xs:element name="title" type="xs:string"/>
+            <xs:element name="givenName" type="xs:string"/>
+            <xs:element name="middleName" type="xs:string"/>
+            <xs:element name="familyName" type="xs:string"/>
+            <xs:element name="familyNamePrefix" type="xs:string"/>
+            <xs:element name="nameSuffix" type="xs:string"/>
+            <xs:element name="gender" type="xs:string"/>
+            <xs:element name="alias" type="xs:string"/>
+        </xs:sequence>
+    </xs:complexType>
 
 </xs:schema>

--- a/src/main/resources/contract/Activity_CommonTypes.xsd
+++ b/src/main/resources/contract/Activity_CommonTypes.xsd
@@ -121,10 +121,10 @@
                 <xs:element name="ports" type="xs:string"  minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="areas" type="xs:string"  minOccurs="0" maxOccurs="unbounded"/>
                 <xs:element name="vesselIdentifiers" type="VesselIdentifierType" minOccurs="0" maxOccurs="unbounded"/>
-				<xs:element name="occurence" minOccurs="0" maxOccurs="1" type="xs:dateTime"/>
-                <xs:element name="landingReferencedID" minOccurs="0" maxOccurs="1" type="xs:string"/>
-                <xs:element name="landingState" minOccurs="0" maxOccurs="1" type="xs:string"/>
-                <xs:element name="vesselContactParty" type="VesselContactPartyType" minOccurs="0" maxOccurs="1"/>
+				<xs:element name="occurence" minOccurs="0" type="xs:dateTime"/>
+                <xs:element name="landingReferencedID" minOccurs="0" type="xs:string"/>
+                <xs:element name="landingState" minOccurs="0" type="xs:string"/>
+                <xs:element name="vesselContactParty" type="VesselContactPartyType" minOccurs="0"/>
             </xs:sequence>
     </xs:complexType>
 
@@ -238,14 +238,14 @@
     <xs:complexType name="VesselContactPartyType">
         <xs:sequence>
             <xs:element name="role" type="xs:string"/>
-            <xs:element name="title" type="xs:string"/>
-            <xs:element name="givenName" type="xs:string"/>
-            <xs:element name="middleName" type="xs:string"/>
-            <xs:element name="familyName" type="xs:string"/>
-            <xs:element name="familyNamePrefix" type="xs:string"/>
-            <xs:element name="nameSuffix" type="xs:string"/>
-            <xs:element name="gender" type="xs:string"/>
-            <xs:element name="alias" type="xs:string"/>
+            <xs:element name="title" minOccurs="0" type="xs:string"/>
+            <xs:element name="givenName" minOccurs="0" type="xs:string"/>
+            <xs:element name="middleName" minOccurs="0" type="xs:string"/>
+            <xs:element name="familyName" minOccurs="0" type="xs:string"/>
+            <xs:element name="familyNamePrefix" minOccurs="0" type="xs:string"/>
+            <xs:element name="nameSuffix" minOccurs="0" type="xs:string"/>
+            <xs:element name="gender" minOccurs="0" type="xs:string"/>
+            <xs:element name="alias" minOccurs="0" type="xs:string"/>
         </xs:sequence>
     </xs:complexType>
 


### PR DESCRIPTION
The Belgian auction uses a custom Exchange plugin to send sales reports to the Union Sales module.
This custom Exchange plugin also allows to query the Union Activity module for fishing activity data.
The Activity module existing FishingTripRequest and FishingTripResponse have been chosen to query fishing activity data for a given vessel and time period.

The required changes to the Activity module are:
+ a new optional search filter type (CONTACT_ROLE_CODE) for the FishingTripRequest.
+ some more optional response data for the FishingTripResponse FishingActivitySummary.

Activity_CommonTypes.xsd:
<xs:complexType name="FishingActivitySummary">
                               <xs:sequence>
                                               <!-- newly added elements -->
                                               <xs:element name="occurence" minOccurs="0" type="xs:dateTime"/>
                                               <xs:element name="landingReferencedID" minOccurs="0" type="xs:string"/>
                                               <xs:element name="landingState" minOccurs="0" type="xs:string"/>
                                               <xs:element name="vesselContactParty" type="VesselContactPartyType" minOccurs="0" maxOccurs="1"/>
                               </xs:sequence>
</xs:complexType>

<xs:complexType name="VesselContactPartyType">
                <xs:sequence>
                               <xs:element name="role" type="xs:string"/>
                               <xs:element name="title" minOccurs="0" type="xs:string"/>
                               <xs:element name="givenName" minOccurs="0" type="xs:string"/>
                               <xs:element name="middleName" minOccurs="0" type="xs:string"/>
                               <xs:element name="familyName" minOccurs="0" type="xs:string"/>
                               <xs:element name="familyNamePrefix" minOccurs="0" type="xs:string"/>
                               <xs:element name="nameSuffix" minOccurs="0" type="xs:string"/>
                               <xs:element name="gender" minOccurs="0" type="xs:string"/>
                               <xs:element name="alias" minOccurs="0" type="xs:string"/>
                </xs:sequence>
</xs:complexType>

These changes are necessary to support the Belgian auction business case where sales report data is to be enriched with data coming from the Activity module.
